### PR TITLE
Require explicit setting to attempt to refresh the Basecamp API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,22 @@ $list = $config->get('list');
   
 Basecamp::createTodo($project, $list, $data);
 ```
+
+
+## Proper setup & configuration of the refresh token
+At this time, creating the initial access & refresh token is the purview of the developer (and it is pretty easy -- see https://github.com/basecamp/api/blob/master/sections/authentication.md).
+
+1. Sign in to Basecamp with the user ID that will provide the integration (in most cases, this should be identified as a non-human account so that people know that actions performed are being triggered by the Drupal integration).
+2. Go to https://launchpad.37signals.com/integrations and use the Authorization dialog to generate a 1-time code.
+3. Trade this code for a [long-lived access token & refresh token](https://github.com/basecamp/api/blob/master/sections/authentication.md#oauth-2-from-scratch):
+
+```bash
+curl -X POST -d "type=web_server&client_id=your-client-id&redirect_uri=your-redirect-uri&client_secret=your-client-secret&code=verification-code" https://launchpad.37signals.com/authorization/token
+```
+
+4. Set these tokens in Drupal's non-config-exportable State API:
+
+```
+vendor/bin/drush state:set basecamp_api_refresh_token <your token>
+vendor/bin/drush state:set basecamp_api_access_token <your token>
+```

--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ curl -X POST -d "type=web_server&client_id=your-client-id&redirect_uri=your-redi
 vendor/bin/drush state:set basecamp_api_refresh_token <your token>
 vendor/bin/drush state:set basecamp_api_access_token <your token>
 ```
+
+5. **Important**: by default, this token will not refresh via cron so that development environments don't accidentally invalidate your access token in the production environment. For the token to be refreshed regularly in your production environment, add the following to your `settings.php` or equivalent:
+
+```
+$settings['basecamp_api_do_refresh'] = TRUE;
+```

--- a/basecamp_api.module
+++ b/basecamp_api.module
@@ -5,13 +5,16 @@
  */
 
 use Drupal\basecamp_api\Basecamp;
+use Drupal\Core\Site\Settings;
 
 function basecamp_api_cron() {
   $interval = 24*60*60; // Run approximately once a day.
   $next_execution = \Drupal::state()->get('basecamp_api.next_cron');
   $next_execution = !empty($next_execution) ? $next_execution : 0;
   if (REQUEST_TIME >= $next_execution) {
-    Basecamp::refreshToken();
+    if (Settings::get('basecamp_api_do_refresh')) {
+      Basecamp::refreshToken();
+    }
     \Drupal::state()->set('basecamp_api.next_cron', REQUEST_TIME + $interval);
   }
 }


### PR DESCRIPTION
Fixes #1﻿
